### PR TITLE
Added sanity check to 3-argument module call.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -197,6 +197,10 @@ AngularPlugin.prototype = {
     var mod = parser.evaluateExpression(expr.arguments[0]);
     var deps = parser.evaluateExpression(expr.arguments[1]);
     this._addModuleDefinition(parser, expr, mod);
+    // Some libraries, such as angular-classy, will break compilation without this check
+    if( !deps.items ){
+      return true;
+    }
     return deps.items.every(
       this._addDependency.bind(this, parser, expr));
   },


### PR DESCRIPTION
Fixes errors encountered with angular-classy, and plausibly anything else that does not explicitly define dependencies.

Protects against calls such as the one found [here](https://github.com/davej/angular-classy/blob/master/angular-classy.js#L41)
