### PR TITLE
Fix ngRoute and others angular modules including

### DIFF
--- a/demo/bower.json
+++ b/demo/bower.json
@@ -13,6 +13,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.2.24"
+    "angular": "~1.2.24",
+    "angular-route": "~1.2.24"
   }
 }

--- a/demo/myApp.js
+++ b/demo/myApp.js
@@ -1,4 +1,4 @@
-var myApp = angular.module('myApp', ['dependency']);
+var myApp = angular.module('myApp', ['dependency', 'ngRoute']);
 
 myApp.run(function($document){
     $document[0].write('Hello from myApp. ');

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,5 +1,6 @@
 var AngularPlugin = require('angular-webpack-plugin');
 var path = require('path');
+
 module.exports = {
     entry: "myApp",
     output: {
@@ -7,7 +8,14 @@ module.exports = {
         filename: "generated_bundle.js"
     },
     resolve: {
-        root: [ process.cwd(), path.resolve('bower_components') ]
+        root: [ process.cwd(), path.resolve('bower_components') ],
+        alias:{
+            // This is needed because the module name doesn't match the file name
+            // but we don't need to locate the file because it is a bower component
+            // with a file name the same as the directory (component) name:
+            //  bower_components/angular-route/angular-route
+            ngRoute: 'angular-route'
+        }
     },
     plugins: [new AngularPlugin()]
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,6 +80,11 @@ AngularPlugin.prototype = {
 
   // This injects the angular module wherever it's used.
   addAngularVariable: function(parser) {
+    //support window.angular usage too
+    parser.plugin("expression window.angular", function(expr) {
+      return ModuleParserHelpers.addParsedVariable(this, 'angular', "require('exports?window.angular!angular')");
+    });
+
     return ModuleParserHelpers.addParsedVariable(parser, 'angular', "require('exports?window.angular!angular')");
   },
 


### PR DESCRIPTION
As we can see, angular modules like angular-route declared in self avocation function:

```
(function(window, angular, undefined){
   angular.module('ngResource', ...
})(window, window.angular);
```

So plugin should support window.angular variable using too.
