### PR TITLE
Add the verbose and noParse options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,6 @@
 // Main entry point of the angular-webpack-plugin module
 // Defines a plugin for webpack to help it understand angular modules.
 
-// 10-2015: Modified to support verbose and noParse options 
-// by James Robey <jrobey.services@gmail.com>
-
 var path = require('path');
 
 var LocalModulesHelpers = require("webpack/lib/dependencies/LocalModulesHelpers");

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,9 @@
 // Main entry point of the angular-webpack-plugin module
 // Defines a plugin for webpack to help it understand angular modules.
 
+// 10-2015: Modified to support verbose and noParse options 
+// by James Robey <jrobey.services@gmail.com>
+
 var path = require('path');
 
 var LocalModulesHelpers = require("webpack/lib/dependencies/LocalModulesHelpers");
@@ -14,7 +17,27 @@ var RequireHeaderDependency = require("webpack/lib/dependencies/RequireHeaderDep
 var AngularModuleDependency = require('./AngularModuleDependency');
 var AngularModuleDefinition = require('./AngularModuleDefinition');
 
-function AngularPlugin() {
+//options provided will apply to all instances of AngularPlugin, but
+//usage with webpack requires only a single instance. This eases
+//access to these options in contexts without access to AngularPlugin
+//during compilation, below.
+var noParse, verbose;
+function AngularPlugin(options) {
+  
+  //should we print information to the console about angular 
+  //modules and dependencies as we find/process them?
+  verbose = options.verbose;
+  
+  //specify angular module dependencies that should be ignored:
+   
+  //a dictionary where the keys are exact angular modules names (or "*",
+  //for matching all modules) where the value is either one, or a list, 
+  //of strings and/or regexes that, if they match a dependency specified on an 
+  //angular module definition, will be ignored as a dependency to be
+  //handled by webpack. This is essential when porting projects to 
+  //webpack whose source may not change to accomodate webpack conventions 
+  //as is the case, for instance, with angular-ui-bootstrap builtin templates.
+  noParse = options.noParse || {};
 }
 
 module.exports = AngularPlugin;
@@ -84,10 +107,28 @@ AngularPlugin.prototype = {
   addAngularVariable: function(parser) {
     return ModuleParserHelpers.addParsedVariable(parser, 'angular', "require('exports?window.angular!angular')");
   },
-
+  
+  lastModule:false,
+  lastContext:false,
+  lastRawRequest:false,
+  
   // Each call to `angular.module()` is analysed here
   parseModuleCall: function(parser, expr){
     this.addAngularVariable(parser);
+    
+    if(verbose && this.lastContext != parser.state.current.context){
+      console.log("\ncd", parser.state.current.context);
+      this.lastContext = parser.state.current.context;
+    }
+    
+    if(verbose && this.lastRawRequest != parser.state.current.rawRequest){
+      console.log("\n    require(\""+parser.state.current.rawRequest+"\")");
+      this.lastRawRequest = parser.state.current.rawRequest;
+    }
+    
+    this.lastModule = expr.arguments[0].value;  
+    verbose && console.log("        angular.module(\""+this.lastModule+"\")");
+    
     switch(expr.arguments.length){
       case 1: return this._parseModuleCallSingleArgument(parser, expr);
       case 2: return this._parseModuleCallTwoArgument(parser, expr);
@@ -214,7 +255,7 @@ AngularPlugin.prototype = {
     parser.state.current.addDependency(dep);
     return true;
   },
-
+  
   // A dependency (module) has been found
   _addDependency: function(parser, expr, param){
     if( param.isConditional() ){
@@ -232,13 +273,32 @@ AngularPlugin.prototype = {
       return true;
     }
     if( param.isString() ){
-      var dep;
-      var localModule = LocalModulesHelpers.getLocalModule(parser.state, param.string);
+      var dep, localModule;
+      
+      //see JROBEY comment above; skip paths that refer to templates that defy dependency "rules".
+      for(var key in noParse){
+        if(key == '*' || key == this.lastModule){
+          var to_match = noParse[key] instanceof Array ? noParse[key] : [noParse[key]];
+          
+          for(var i = 0; i !== to_match.length; i ++){
+            var consider = to_match[i];
+        
+            if((consider.exec && consider.exec(param.string)) || param.string == consider){
+              verbose && console.log("            (skip", param.string+")");
+              return true;
+            }
+          }
+        } 
+      }
+      
+      localModule = LocalModulesHelpers.getLocalModule(parser.state, param.string);
       if( localModule ) {
         return true;
       }
+      
       dep = new AngularModuleDependency(param.string, param.range);
       dep.loc = param.loc;
+      verbose && param.string !== this.lastModule && console.log("            ", param.string);
       parser.state.current.addDependency(dep);
       return true;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,10 +23,11 @@ var AngularModuleDefinition = require('./AngularModuleDefinition');
 //during compilation, below.
 var noParse, verbose;
 function AngularPlugin(options) {
+  options = options || {};
   
   //should we print information to the console about angular 
   //modules and dependencies as we find/process them?
-  verbose = options.verbose;
+  verbose = options.verbose || false;
   
   //specify angular module dependencies that should be ignored:
    


### PR DESCRIPTION
There are cases where angular code intended to be processed by webpack cannot be modified to adapt to webpack. In these cases, certain dependencies of angular.module() statements will never comply with webpack resolve rules, as is the case with angular-ui-bootstrap's builtin templates.

The major option here, noParse, allows this plugin to be configured to ignore matching dependencies either globally, or on certain modules only when the developer knows that dependency will be satisfied at runtime without help from webpack.

The second option, verbose, simply pretty prints information to the console as angular modules are discovered and their dependencies added which can be useful for beginners understanding what this plugin does.

Tests will not pass because the current version of webpack outputs a format (bundle.js) different than the ones contained in the current test. I would like to submit a pull request for that separately.

Using this plugin for an enterprise project where the codebase may not be touched, hence the interest in contributing back what it took to get a clean build of our project.